### PR TITLE
Allow the fallthroughHandler() and proxyHandler() to be used programmatically

### DIFF
--- a/dist/handlers.js
+++ b/dist/handlers.js
@@ -63,9 +63,10 @@ var makeHandlers = exports.makeHandlers = function makeHandlers(_ref) {
     proxyHandler: function proxyHandler() {
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
-      _.log('setting up proxy to ' + config.proxy);
+      var proxyUrl = config.proxy || options.proxy;
+      _.log('setting up proxy to ' + proxyUrl);
       var proxy = httpProxy.createProxyServer({ protocolRewrite: 'https:', autoRewrite: true });
-      var target = url.parse(config.proxy);
+      var target = url.parse(proxyUrl);
 
       proxy.on('proxyReq', function (proxyReq, req, res, proxyOptions) {
         proxyReq.setHeader('X-Forwarded-Proto', 'https');
@@ -87,12 +88,12 @@ var makeHandlers = exports.makeHandlers = function makeHandlers(_ref) {
       });
 
       return function (req, res, next) {
-        _.log(req.method + ' https://' + req.headers.host + req.url + ' => ' + config.proxy);
-        return proxy.web(req, res, { target: config.proxy });
+        _.log(req.method + ' https://' + req.headers.host + req.originalUrl + ' => ' + proxyUrl);
+        return proxy.web(req, res, { target: proxyUrl });
       };
     },
 
-    defaultHandler: function defaultHandler() {
+    fallthroughHandler: function fallthroughHandler() {
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
       var _merge2 = merge({
@@ -102,13 +103,19 @@ var makeHandlers = exports.makeHandlers = function makeHandlers(_ref) {
       }, options),
           fallthroughHandler = _merge2.fallthroughHandler;
 
+      return fallthroughHandler;
+    },
+
+    defaultHandler: function defaultHandler() {
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
       var app = express();
       app.use(handlers.bundle());
       app.use(handlers.static());
       if (config.proxy) {
         app.use(handlers.proxyHandler());
       }
-      app.use(fallthroughHandler);
+      app.use(handlers.fallthroughHandler());
       return app;
     }
   };

--- a/dist/index.js
+++ b/dist/index.js
@@ -327,11 +327,23 @@ var init = function init() {
   // f: notify system that a file has changed
   _.fileChanged = function (absolutePath) {
     _.log('file-changed: ' + _path2.default.relative(config.directories.root, absolutePath));
+
+    // Knock the file out of the builder cache.
+    var url = _path2.default.relative(config.directories.baseURL, absolutePath);
+    if (_.builder.cache.compile.loads[url]) {
+      _.log('cache-evicted: ' + url);
+      delete _.builder.cache.compile.loads[url];
+      delete _.builder.cache.trace[url];
+    } else {
+      // TODO: should we bust the entire cache on node_modules/jspm_packages updates here?
+      _.log('ignored: ' + url);
+    }
+
     _.events.next({
       type: 'file-changed',
       absolutePath: absolutePath,
       relativePath: _path2.default.relative(config.directories.root, absolutePath),
-      url: _path2.default.relative(config.directories.baseURL, absolutePath)
+      url: url
     });
   };
 

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -44,9 +44,10 @@ export const makeHandlers = ({_, config}) => {
     // },
 
     proxyHandler: (options = {}) => {
-      _.log('setting up proxy to ' + config.proxy)
+      const proxyUrl = config.proxy || options.proxy;
+      _.log('setting up proxy to ' + proxyUrl)
       let proxy = httpProxy.createProxyServer({protocolRewrite: 'https:', autoRewrite: true})
-      let target = url.parse(config.proxy)
+      let target = url.parse(proxyUrl)
 
       proxy.on('proxyReq', (proxyReq, req, res, proxyOptions) => {
         proxyReq.setHeader('X-Forwarded-Proto', 'https')
@@ -68,26 +69,28 @@ export const makeHandlers = ({_, config}) => {
       })
 
       return (req, res, next) => {
-        _.log(`${req.method} https://${req.headers.host}${req.url} => ${config.proxy}`)
-        return proxy.web(req, res, { target: config.proxy });
+        _.log(`${req.method} https://${req.headers.host}${req.originalUrl} => ${proxyUrl}`)
+        return proxy.web(req, res, { target: proxyUrl });
       }
     },
 
-    defaultHandler: (options = {}) => {
-
+    fallthroughHandler: (options = {}) => {
       const {fallthroughHandler} = merge({
         fallthroughHandler: (req, res) => {
           defaultFinalHandler(req, res)()
         }
-      }, options)
+      }, options);
+      return fallthroughHandler;
+    },
 
+    defaultHandler: (options = {}) => {
       const app = express()
       app.use(handlers.bundle())
       app.use(handlers.static())
       if (config.proxy) {
-        app.use(handlers.proxyHandler());
+        app.use(handlers.proxyHandler())
       }
-      app.use(fallthroughHandler)
+      app.use(handlers.fallthroughHandler())
       return app
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -240,11 +240,23 @@ const init = (configOverrides = {}) => {
   // f: notify system that a file has changed
   _.fileChanged = (absolutePath) => {
     _.log(`file-changed: ${path.relative(config.directories.root, absolutePath)}`);
+
+    // Knock the file out of the builder cache.
+    const url = path.relative(config.directories.baseURL, absolutePath);
+    if (_.builder.cache.compile.loads[url]) {
+      _.log(`cache-evicted: ${url}`);
+      delete _.builder.cache.compile.loads[url];
+      delete _.builder.cache.trace[url];
+    } else {
+      // TODO: should we bust the entire cache on node_modules/jspm_packages updates here?
+      _.log(`ignored: ${url}`);
+    }
+
     _.events.next({
       type: 'file-changed',
       absolutePath,
       relativePath: path.relative(config.directories.root, absolutePath),
-      url: path.relative(config.directories.baseURL, absolutePath)
+      url: url
     })
   }
 


### PR DESCRIPTION
I decided I could not resolve the complexities of my application's back-end proxy requirements so decided to punt with configuration and use the handlers API programmatically. As a result, I decided to expose the two handler types: fallback and proxy, and this is the result.

Thanks for being responsive, and how can we get an official release of this to npm at some point?