### PR TITLE
Fixes #14: invalidate cache taking baseURL into account

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -157,7 +157,7 @@ var init = function init() {
   _.invalidate = function (_ref) {
     var absolutePath = _ref.absolutePath;
 
-    _.builder.invalidate(absolutePath);
+    _.builder.invalidate(_path2.default.relative(config.directories.baseURL, absolutePath));
 
     var normalized = _path2.default.normalize(_path2.default.relative(_path2.default.join(config.directories.root, config.directories.baseURL), absolutePath));
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ const init = (configOverrides = {}) => {
   }
 
   _.invalidate = ({absolutePath}) => {
-    _.builder.invalidate(absolutePath)
+    _.builder.invalidate(path.relative(config.directories.baseURL, absolutePath))
 
     const normalized = path.normalize(
       path.relative(path.join(config.directories.root, config.directories.baseURL), absolutePath)


### PR DESCRIPTION
This should be a much cleaner way of dealing with cache invalidation.