### PR TITLE
Tweak for proxying to https targets

### DIFF
--- a/dist/handlers.js
+++ b/dist/handlers.js
@@ -103,7 +103,7 @@ var makeHandlers = exports.makeHandlers = function makeHandlers(_ref) {
 
       var proxyUrl = config.proxy || options.proxy;
       _.log('setting up proxy to ' + proxyUrl);
-      var proxy = httpProxy.createProxyServer({ protocolRewrite: 'https:', autoRewrite: true });
+      var proxy = httpProxy.createProxyServer({ protocolRewrite: 'https:', autoRewrite: true, secure: 'secure' in options ? options.secure : false });
       var target = url.parse(proxyUrl);
 
       proxy.on('proxyReq', function (proxyReq, req, res, proxyOptions) {

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -78,7 +78,7 @@ export const makeHandlers = ({_, config}) => {
     proxyHandler: (options = {}) => {
       const proxyUrl = config.proxy || options.proxy;
       _.log('setting up proxy to ' + proxyUrl)
-      let proxy = httpProxy.createProxyServer({protocolRewrite: 'https:', autoRewrite: true})
+      let proxy = httpProxy.createProxyServer({protocolRewrite: 'https:', autoRewrite: true, secure: ('secure' in options ? options.secure : false)})
       let target = url.parse(proxyUrl)
 
       proxy.on('proxyReq', (proxyReq, req, res, proxyOptions) => {


### PR DESCRIPTION
For proxying to https targets, set the "secure" property false as to
allow for easier development workflow to internal servers.